### PR TITLE
DDDP 1088 & 1089

### DIFF
--- a/web/admin/src/PresentationDriver.js
+++ b/web/admin/src/PresentationDriver.js
@@ -330,5 +330,5 @@ export default class PresentationDriver extends PureComponent {
 
 function sortUsers(a, b) {
   if (a.score !== b.score) return b.score - a.score
-  return b.time - a.time
+  return a.time - b.time
 }


### PR DESCRIPTION
Leaderboard not working correctly as sorting of users was backwards which was preventing the tie breaker for place from working as well